### PR TITLE
Don't escape html for form error message

### DIFF
--- a/code/SilverChimpSubscriptionPage.php
+++ b/code/SilverChimpSubscriptionPage.php
@@ -342,7 +342,7 @@ class SilverChimpSubscriptionPage_Controller extends Page_Controller {
             
         } else {
             //    failure!
-            $form->sessionMessage($this->api->errorMessage, 'warning');
+            $form->sessionMessage($this->api->errorMessage, 'warning', false);
             return $this;
         }
     }

--- a/code/SilverChimpSubscriptionPage.php
+++ b/code/SilverChimpSubscriptionPage.php
@@ -197,6 +197,11 @@ class SilverChimpSubscriptionPage_Controller extends Page_Controller {
         }
 
         $mergeVars = $this->api->listMergeVars($this->ListID);
+        
+        if(false === $mergeVars) {
+            return $this->api->errorMessage;
+        }
+        
         $fields = array();
         $required = array();
         


### PR DESCRIPTION
Useful when mailchimp returns links
